### PR TITLE
Could org.jpmml:jpmml-r:1.4-SNAPSHOT drop off redundant dependencies to loose weight?

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,16 @@
 			<groupId>org.jpmml</groupId>
 			<artifactId>jpmml-converter</artifactId>
 			<version>1.4.6</version>
+			<exclusions>
+                		<exclusion>
+                    			<groupId>org.glassfish.jaxb</groupId>
+                    			<artifactId>jaxb-runtime</artifactId>
+                		</exclusion>
+                		<exclusion>
+                    			<groupId>org.jpmml</groupId>
+                    			<artifactId>pmml-agent</artifactId>
+                		</exclusion>
+            		</exclusions>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
@vruusmann Hi, I am a user of project **_org.jpmml:jpmml-r:1.4-SNAPSHOT_**. I found that its pom file introduced **_29_** dependencies. However, among them, **_4_** libraries (**_13%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_org.jpmml:jpmml-r:1.4-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
com.sun.activation:jakarta.activation:jar:1.2.2:runtime
org.jpmml:pmml-agent:jar:1.5.11:compile
org.glassfish.jaxb:jaxb-runtime:jar:2.3.3:compile
com.sun.istack:istack-commons-runtime:jar:3.0.11:compile
</code></pre>